### PR TITLE
Include SVCB/HTTPS records in Resolution Delay definition

### DIFF
--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -851,8 +851,8 @@ provided by the application ({{literals}}).
 The values that may be configured as defaults on a client for use in
 Happy Eyeballs are as follows:
 
-- Resolution Delay ({{resolution}}): The time to wait for a AAAA record
-after receiving an A record. Recommended to be 50 milliseconds.
+- Resolution Delay ({{resolution}}): The time to wait for AAAA and/or SVCB/HTTPS
+records after receiving an A record. Recommended to be 50 milliseconds.
 
 - Preferred Address Family Count ({{sorting}}): The number of
 addresses belonging to the preferred address family (such as IPv6)


### PR DESCRIPTION
Section 4.2. "Handling DNS Answers Asynchronously" says the resolution delay is used to wait for both AAAA and SVCB/HTTPS records:

> The resolution time delay is a short time that provides a chance to receive
preferred addresses (via AAAA records) along with service information (via SVCB/HTTPS records). This accounts for the case where the AAAA or SVCB/HTTPS records follow the A records by a few milliseconds. This delay is referred to as the "Resolution Delay".

Yet the Resolution Delay definition in section 9. "Summary of Configurable Values" only mentions AAAA:

> Resolution Delay (Section 4): The time to wait for a AAAA record after
receiving an A record. Recommended to be 50 milliseconds.

This commit updates the latter to include the mention of SVCB/HTTPS in addition to AAAA.