### PR TITLE
Replace interface with PvD

### DIFF
--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -458,14 +458,15 @@ client's IP address during authentication, as is the case for TCP
 Fast Open {{?RFC7413}} and some Hypertext Transport Protocol (HTTP)
 cookies. This historical data MUST be partitioned using the same
 boundaries used for privacy-sensitive information specific to that endpoint,
-and MUST NOT be used across different network interfaces. The data SHOULD
-be flushed whenever a device changes the network to which it is attached.
-However, if a client can reliably identify a previously attached network,
-it MAY retain and resume using historical data associated with that network
-upon reconnection. Clients that use historical data MUST ensure that clients
-with different historical data will eventually converge toward the same
-behaviors. For example, clients can periodically ignore historical data to
-ensure that fresh addresses are attempted.
+and MUST NOT be used across different Provisioning Domains (PvDs)
+{{?RFC7556}}. The data SHOULD be flushed whenever a device changes the
+PvD to which it is attached. However, if a client can reliably
+identify a previously attached PvD, it MAY retain and resume using
+historical data associated with that PvD upon reconnection. Clients
+that use historical data MUST ensure that clients with different
+historical data will eventually converge toward the same behaviors.
+For example, clients can periodically ignore historical data to ensure
+that fresh addresses are attempted.
 
 Next, the client SHOULD modify the ordered list to interleave
 address families. Whichever address family is first in the list


### PR DESCRIPTION
I can also replace "network" with PvD in many more places, but I wasn't sure if that added clarity.

Closes #123.