### PR TITLE
Rewrite IPv6-only/NAT64 text based on design team discussion

### DIFF
--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -149,7 +149,7 @@ and asynchronously handles the answers.
 Clients first need to determine which DNS resource records
 they will include in queries for a named host.
 
-This decision is based on if client has "connectivity" using IPv4
+This decision is based on whether the client has "connectivity" using IPv4
 and/or IPv6 on the current Provisioning Domain (PvD) {{?PvD=RFC7556}}.
 Generally, "connectivity" for an address family is defined
 as having at least one local address of the family from which

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -144,24 +144,24 @@ by sending DNS queries and collecting the answers.
 This section describes how a client initiates DNS queries
 and asynchronously handles the answers.
 
-## Sending DNS Queries
+## Sending DNS Queries {#queries}
 
 Clients first need to determine which DNS resource records
 they will include in queries for a named host.
 
-This decision is based on if client has "connectivity" using IPv4 and IPv6.
-In this case, "connectivity" for an address family is defined
+This decision is based on if client has "connectivity" using IPv4
+and/or IPv6 on the current provisioning domain (PvD) {{?PvD=RFC7556}}.
+Generally, "connectivity" for an address family is defined
 as having at least one local address of the family from which
 to send packets, and at least one non-link local route for
-the address family.
+the address family. When there is IPv6 connectivity, the client
+MUST include a query for AAAA records. When there is IPv4 connectivity,
+the client MUST include a query for A records. Additionally,
+if the client has detected a NAT64 prefix ({{!NAT64=RFC6146}})
+on the network, the client MUST include a query for A records
+(see {{nat64}} for more details on detecting the NAT64 prefix
+and handling answers).
 
-When a client has both IPv4 and IPv6 connectivity, it needs to
-send out queries for both AAAA and A records. On a network with
-only IPv4 connectivity, it will send a query for A records. On a
-network with only IPv6 connectivity, the client will either send
-out queries for both AAAA and A records, or only a query for AAAA
-records, depending on the network configuration. See {{v6only}}
-for more discussion of handling IPv6-mostly and IPv6-only networks.
 
 In addition to requesting AAAA and A records, depending on which
 application is establishing the connection, clients can request
@@ -667,7 +667,7 @@ Fast Open {{?RFC7413}} and some Hypertext Transport Protocol (HTTP)
 cookies. This historical data MUST be partitioned using the same
 boundaries used for privacy-sensitive information specific to that endpoint,
 and MUST NOT be used across different Provisioning Domains (PvDs)
-{{?RFC7556}}. The data SHOULD be flushed whenever a device changes the
+{{PvD}}. The data SHOULD be flushed whenever a device changes the
 PvD to which it is attached. However, if a client can reliably
 identify a previously attached PvD, it MAY retain and resume using
 historical data associated with that PvD upon reconnection. Clients
@@ -946,69 +946,56 @@ the previous addresses may no longer be viable and fire the timer sooner
 to start a connection attempt to the next address in the updated list, subject
 to the Minimum Connection Attempt Delay.
 
-# Supporting IPv6-Mostly and IPv6-Only Networks {#v6only}
+# Handling NAT64 Networks {#nat64}
 
-While many IPv6 transition protocols have been standardized and
-deployed, most are transparent to client devices. Supporting IPv6-only
-networks often requires specific client-side changes, especially when
-interacting with IPv4-only services. Two primary mechanisms for this
-are the combined use of NAT64 {{!RFC6146}} with DNS64 {{!RFC6147}}, or
-leveraging NAT64 with a discovered PREF64 prefix {{!RFC8781}}.
+NAT64 {{NAT64}} is an IPv6 transition protocol that allows
+clients with IPv6-only connectivity to access IPv4-only peers
+outside the local link. When NAT64 is in use, an IPv6 prefix,
+referred to as PREF64, is used on by the NAT for synthesizing
+IPv4 addresses into IPv6 addresses.
 
-One possible way to handle these networks is for the client device
-networking stack to implement 464XLAT {{?RFC6877}}. 464XLAT has the
-advantage of not requiring changes to user space software; however, it
-requires per-packet translation if the application is using IPv4
-literals and does not encourage client application software to support
-native IPv6. On platforms that do not support 464XLAT, the Happy
-Eyeballs engine SHOULD follow the recommendations in this section to
-properly support IPv6-mostly ({{?V6-MOSTLY=I-D.ietf-v6ops-6mops}}) and IPv6-only networks.
+## Discovering PREF64
 
-The features described in this section SHOULD only be enabled when the
-host detects an IPv6-mostly or IPv6-only network. A simple heuristic
-to detect one of these networks is to check if the network offers
-routable IPv6 addressing, does not offer routable IPv4 addressing, and
-offers a DNS resolver address.
+Clients can discover a network's PREF64 in one of the following ways:
 
-## IPv4 Address Literals {#literals}
+1. From a Router Advertisement option ({{!PREF64=RFC8781}})
 
-If client applications or users wish to connect to IPv4 address
-literals, the Happy Eyeballs engine will need to perform NAT64 address
-synthesis for them. The solution is similar to "Bump-in-the-Host"
-{{!RFC6535}} but is implemented inside the Happy Eyeballs client.
+1. From a DNS query for ipv4only.arpa ({{!RFC7050}})
 
-Note that some IPv4 prefixes are scoped to a given host or network,
-such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and
-255.255.255.255/32, and therefore do not require NAT64 address
-synthesis.
+If a network with IPv6-only connectivity does not provide the prefix
+in a Router Advertisement {{PREF64}}, clients SHOULD send the DNS
+query to discover the prefix {{RFC7050}}.
 
-## Discovering and Utilizing PREF64 {#pref64-detection}
+Networks that use NAT64 might also include DNS64 {{?DNS64=RFC6147}},
+in which the DNS resolver synthesizes A answers into AAAA answers.
+However, with the prefix available from router advertisements {{PREF64}},
+networks might choose to not deploy DNS64, as the latter has a number
+of disadvantages (see {{Section 4.3.4 of ?V6-MOSTLY=I-D.ietf-v6ops-6mops}}).
 
-When an IPv4 address is passed into the Happy Eyeballs implementation
-instead of a hostname, it SHOULD use PREF64s received from Router
-Advertisements {{!RFC8781}}.
+To ensure compatibility with any NAT64 network, whenever the client
+detects a NAT64 prefix, from either of the options reference above,
+clients MUST send A queries in addition to AAAA queries (as
+specified in {{queries}}). This allows the client to receive any
+existing IPv4 A records and perform local NAT64 address synthesis,
+eliminating the network's need to run DNS64.
 
-With PREF64 available, networks might choose to not deploy DNS64, as
-the latter has a number of disadvantages (see
-{{V6-MOSTLY, Section 4.3.4}}). To ensure
-compatibility with such networks, if PREF64 is available, clients
-SHOULD send an A query in addition to an AAAA query for a given
-hostname. This allows the client to receive any existing IPv4 A
-records and perform local NAT64 address synthesis, eliminating the
-network's need to run DNS64.
+## Synthesizing IPv6 Addresses
 
-If the network does not provide PREF64s, the implementation SHOULD
-query the network for the NAT64 prefix using "Discovery of the IPv6
-Prefix Used for IPv6 Address Synthesis" {{!RFC7050}}. It then
-synthesizes an appropriate IPv6 address (or several) using the
-encoding described in "IPv6 Addressing of IPv4/ IPv6 Translators"
-{{!RFC6052}}. The synthesized addresses are then inserted into the
-list of addresses as if they were results from DNS A queries;
-connection attempts follow the algorithm described above (see
-{{connections}}).
+When a client has discovered PREF64, it can use the prefix to
+synthesize IPv4 addresses into IPv6 addresses as defined in {{!RFC6052}}.
 
-Such translation also applies to any IPv4 addresses received in A
-records and IPv4 address hints received in SVCB records.
+Such synthesis is performed by the Happy Eyeballs client any
+time it has an IPv4 answer from DNS (from A records or IPv4
+address hints received in SVCB/HTTPS records), or is being
+asked to connect to an IPv4 literal address. The solution is similar
+to "Bump-in-the-Host" {{!RFC6535}} but is implemented inside
+the Happy Eyeballs client.
+
+Note that NAT64 address synthesis is not always required or possible.
+Some IPv4 prefixes are scoped to a given host or network and do not require
+synthesis, such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and 255.255.255.255/32;
+Additionally, there are restrictions on the use of the well-known NAT64
+prefix ({{Section 3.1 of !RFC6052}}) for certain addresses.
 
 ## Supporting DNS64 {#dns64}
 

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -152,14 +152,14 @@ they will include in queries for a named host.
 This decision is based on whether the client has "connectivity" using IPv4
 and/or IPv6 on the current Provisioning Domain (PvD) {{?PvD=RFC7556}}.
 Generally, "connectivity" for an address family is defined
-as having at least one local address of the family from which
-to send packets, and at least one non-link local route for
-the address family. When there is IPv6 connectivity, the client
-MUST include a query for AAAA records. When there is IPv4 connectivity,
-the client MUST include a query for A records. Additionally,
-if the client has detected a NAT64 prefix ({{!NAT64=RFC6146}})
-on the network, the client MUST include a query for A records
-(see {{nat64}} for more details on detecting the NAT64 prefix
+as having at least one non-loopback and and non-link-local ({{!RFC3927}},{{!RFC4291}})
+address of that address family from which to send packets, and at
+least one non-link local route for the address family. When there is
+IPv6 connectivity, the client MUST include a query for AAAA records.
+When there is IPv4 connectivity, the client MUST include a query for
+A records. Additionally, if the client has detected a NAT64 prefix
+({{!NAT64=RFC6146}}) on the network, the client MUST include a query
+for A records (see {{nat64}} for more details on detecting the NAT64 prefix
 and handling answers).
 
 
@@ -979,34 +979,41 @@ specified in {{queries}}). This allows the client to receive any
 existing IPv4 A records and perform local NAT64 address synthesis,
 eliminating the network's need to run DNS64.
 
-## Synthesizing IPv6 Addresses
-
-When a client has discovered PREF64, it can use the prefix to
-synthesize IPv4 addresses into IPv6 addresses as defined in {{!RFC6052}}.
-
-Such synthesis is performed by the Happy Eyeballs client any
-time it has an IPv4 answer from DNS (from A records or IPv4
-address hints received in SVCB/HTTPS records), or is being
-asked to connect to an IPv4 literal address. The solution is similar
-to "Bump-in-the-Host" {{!RFC6535}} but is implemented inside
-the Happy Eyeballs client.
-
-Note that NAT64 address synthesis is not always required or possible.
-Some IPv4 prefixes are scoped to a given host or network and do not require
-synthesis, such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and 255.255.255.255/32;
-
-
-## Sorting and Connecting on NAT64 Networks
+## Handling Synthesized Answers
 
 Synthesized IPv6 addresses (IPv4 addresses that have been
 synthensized into IPv6 addresses either locally using PREF64
-or by a DNS64 resolver) MUST be treated as IPv4 addresses for
-the purpose of Happy Eyeballs grouping and sorting ({{sorting}}).
+or by a DNS64 resolver) MUST be de-synthesized into IPv4 addresses
+before being used by the Happy Eyeballs client for grouping and
+sorting ({{sorting}}), and connecting. These addresses might
+be re-synthesized into IPv6 addresses (see {{synthesizing}}),
+in which case implementations can choose to optimize processing
+by storing the original address, but still using the IPv4 address
+for purposes of sorting and route lookups.
 
 IPv6 addresses received from AAAA records might come from DNS64
 {{DNS64}}. Clients that are aware of the PREF64 value MUST check
 to see if an IPv6 address received from DNS is actually an IPv4
 address.
+
+## Synthesizing IPv6 Addresses During Connection Establishment {#synthesizing}
+
+When a client has discovered PREF64, it can use the prefix to
+synthesize IPv4 addresses into IPv6 addresses as defined in {{!RFC6052}}.
+
+If the Happy Eyeballs client is attempting a connection
+to an IPv4 address when there is no IPv4 route that applies for that
+address, then the client MUST synthesize this address into an
+IPv6 address using the PREF64. These IPv4 addresses can come
+from DNS (via A records or IPv4 address hints received in
+SVCB/HTTPS records), or from de-synthesizing IPv6 addresses,
+or from IPv4 literal addresses passed by an application.
+This solution is similar to "Bump-in-the-Host" {{!RFC6535}},
+but is implemented inside the Happy Eyeballs client.
+
+Note that NAT64 address synthesis is not always required or possible.
+Some IPv4 prefixes are scoped to a given host or network and do not require
+synthesis, such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and 255.255.255.255/32.
 
 # Summary of Configurable Values
 

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -997,71 +997,18 @@ synthesis, such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and 255.255.255.255/3
 Additionally, there are restrictions on the use of the well-known NAT64
 prefix ({{Section 3.1 of !RFC6052}}) for certain addresses.
 
-## Supporting DNS64 {#dns64}
 
-If PREF64 is not available and the NAT64 prefix cannot be discovered,
-clients SHOULD assume the network is relying on DNS64 for IPv4-to-IPv6
-address synthesis. In this scenario, clients will typically only
-receive AAAA records from DNS queries, as DNS64 servers synthese these
-records for IPv4-only domains.
+## Sorting and Connecting on NAT64 Networks
 
-## Hostnames with Broken AAAA Records {#broken}
+Synthesized IPv6 addresses (IPv4 addresses that have been
+synthensized into IPv6 addresses either locally using PREF64
+or by a DNS64 resolver) MUST be treated as IPv4 addresses for
+the purpose of Happy Eyeballs grouping and sorting ({{sorting}}).
 
-At the time of writing, there exist a small but non-negligible number
-of hostnames that resolve to valid A records and broken AAAA records,
-which we define as AAAA records that contain seemingly valid IPv6
-addresses but those addresses never reply when contacted on the usual
-ports. These can be, for example, caused by:
-
-- Mistyping of the IPv6 address in the DNS zone configuration
-
-- Routing black holes
-
-- Service outages
-
-While an algorithm complying with the other sections of this document
-would correctly handle such hostnames on a dual-stack network, they
-will not necessarily function correctly on IPv6-only networks with
-NAT64 and DNS64. Since DNS64 recursive resolvers rely on the
-authoritative name servers sending negative (no error, no data)
-responses for AAAA records in order to synthesize, they will not
-synthesize records for these particular hostnames and will instead
-pass through the broken AAAA record.
-
-In order to support these scenarios, the client device needs to query
-the DNS for the A record and then perform local synthesis. Since
-these types of hostnames are rare and, in order to minimize load on
-DNS servers, this A query should only be performed when the client
-has given up on the AAAA records it initially received. This can be
-achieved by using a longer timeout, referred to as the "Last Resort
-Local Synthesis Delay"; the delay is recommended to be 2 seconds.
-The timer is started when the last connection attempt is fired. If
-no connection attempt has succeeded when this timer fires, the device
-queries the DNS for the IPv4 address and, on reception of a valid A
-record, treats it as if it were provided by the application (see
-{{literals}}).
-
-## Virtual Private Networks
-
-Some Virtual Private Networks (VPNs) may be configured to handle DNS
-queries from the device. The configuration could encompass all
-queries or a subset such as "*.internal.example.com". These VPNs can
-also be configured to only route part of the IPv4 address space, such
-as 192.0.2.0/24. However, if an internal hostname resolves to an
-external IPv4 address, these can cause issues if the underlying
-network is IPv6-only. As an example, let's assume that
-"www.internal.example.com" has exactly one A record, 198.51.100.42,
-and no AAAA records. The client will send the DNS query to the
-company's recursive resolver and that resolver will reply with these
-records. The device now only has an IPv4 address to connect to and
-no route to that address. Since the company's resolver does not know
-the NAT64 prefix of the underlying network, it cannot synthesize the
-address. Similarly, the underlying network's DNS64 recursive
-resolver does not know the company's internal addresses, so it cannot
-resolve the hostname. Because of this, the client device needs to
-resolve the A record using the company's resolver and then locally
-synthesize an IPv6 address, as if the resolved IPv4 address were
-provided by the application ({{literals}}).
+IPv6 addresses received from AAAA records might come from DNS64
+{{DNS64}}. Clients that are aware of the PREF64 value MUST check
+to see if an IPv6 address received from DNS is actually an IPv4
+address.
 
 # Summary of Configurable Values
 

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -1035,9 +1035,6 @@ milliseconds. MUST NOT be less than 10 milliseconds.
 - Maximum Connection Attempt Delay ({{connections}}): The maximum time to
 wait between connection attempts. Recommended to be 2 seconds.
 
-- Last Resort Local Synthesis Delay ({{broken}}): The time to wait
-after starting the last IPv6 attempt and before sending the A
-query. Recommended to be 2 seconds.
 
 The delay values described in this section were determined
 empirically by measuring the timing of connections on a very wide set

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -150,7 +150,7 @@ Clients first need to determine which DNS resource records
 they will include in queries for a named host.
 
 This decision is based on if client has "connectivity" using IPv4
-and/or IPv6 on the current provisioning domain (PvD) {{?PvD=RFC7556}}.
+and/or IPv6 on the current Provisioning Domain (PvD) {{?PvD=RFC7556}}.
 Generally, "connectivity" for an address family is defined
 as having at least one local address of the family from which
 to send packets, and at least one non-link local route for

--- a/draft-ietf-happy-happyeyeballs-v3.md
+++ b/draft-ietf-happy-happyeyeballs-v3.md
@@ -994,8 +994,6 @@ the Happy Eyeballs client.
 Note that NAT64 address synthesis is not always required or possible.
 Some IPv4 prefixes are scoped to a given host or network and do not require
 synthesis, such as 0.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, and 255.255.255.255/32;
-Additionally, there are restrictions on the use of the well-known NAT64
-prefix ({{Section 3.1 of !RFC6052}}) for certain addresses.
 
 
 ## Sorting and Connecting on NAT64 Networks


### PR DESCRIPTION
Attempt at closing IPv6-only network issues, based on design team discussion from IETF 125

Proposal was:

> Define: PvD is all interfaces on which the connection might end up sending packets.
> * If your PvD has non-loopback v4 or contains any known PREF64 prefix, then you MUST send A (since you might end up using it)
> * If your PvD has any non link-local or loopback v6 (global scope), then you MUST send AAAA
> * Will get back v4, v6, or synthesized v6 addresses
>     * If you have the prefix, you SHOULD replace v6 addresses that you can de-synthesize with the real v4 versions using the prefix for the interface on which the DNS query was sent.
>     * These are the same as the native v4 ones from a prioritization perspective
>     * Run the sorting algorithm, native v6 will be preferred